### PR TITLE
Remove trailing / in nixpkgs.nix's git URL

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,7 +1,7 @@
 import (builtins.fetchGit {
   # Descriptive name to make the store path easier to identify
   name = "nixos-unstable-2018-11-20";
-  url = https://github.com/nixos/nixpkgs/;
+  url = https://github.com/nixos/nixpkgs;
   # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
   rev = "80738ed9dc0ce48d7796baed5364eef8072c794d";
 }) {}


### PR DESCRIPTION
A trailing / breaks some git configurations and causes nix-build to fail.